### PR TITLE
jml - added discover page

### DIFF
--- a/language-learning/app/discover/page.tsx
+++ b/language-learning/app/discover/page.tsx
@@ -46,7 +46,7 @@ export default function DiscoverPage() {
   };
 
   return (
-    <div className="min-h-screen bg-white text-black max-w-6xl mx-auto p-6">
+    <div className="min-h-screen bg-white text-black w-full p-6">
       <h2 className="text-3xl font-bold mb-6 text-center">
         Discover Language Partners
       </h2>


### PR DESCRIPTION
Closes #35 

This PR adds file `app/discover/page.tsx`. 

This page has two sections:
* the top panel has a horizantal scroll with recommended partners (currently no real logic, needs to be routed to backend)
* the bottom section displays a list of all language learners, filterable by language search or level dropdown selection (currently showing mock data)

All displayed peers are modeled as cards. The cards contain name, language, and level of the potential partner. In the future, I expect that clicking a card should link to a user's public profile, from which point users can initiate a chat.

I'm not really sure how to deploy this on the shared vercel deployment, but if you run it locally, you can access the page at http://localhost:3000/discover. Otherwise, here's just a snapshot photo:
<img width="1143" height="778" alt="Screenshot 2026-01-23 at 6 08 32 PM" src="https://github.com/user-attachments/assets/3829207f-ac6b-494f-808b-82e66d13c463" />
