### PR TITLE
jml - SSR set up

### DIFF
--- a/language-learning/app/api/discover/route.ts
+++ b/language-learning/app/api/discover/route.ts
@@ -1,31 +1,33 @@
 import { NextRequest, NextResponse } from "next/server";
-import { supabase as supabaseClient } from "@/lib/supabaseClient";
+import { createClient } from '@/lib/supabaseServer'
 
 export async function GET(req: NextRequest) {
+  const supabase = await createClient();
+  const { data: { user }, error: authError } = await supabase.auth.getUser();
+  if (!user || authError) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
   const { searchParams } = new URL(req.url);
   const languageFilter = searchParams.get("language");
   const levelFilter = searchParams.get("level");
   const isRecommended = searchParams.get("recommended") === "true";
 
-  // auth check TBD
-  // const currentUserId = "45c9d31c-0a1f-4b59-8db5-f980e91c8075";
-
-  let query = supabaseClient
+  let query = supabase
     .from("profiles")
     .select(`
       user_id, 
       first_name, 
-      level, 
-      profile_target_languages!inner(language)
+      profile_target_languages!inner(language_id, level)
     `)
-    // .neq('user_id', currentUserId);
+    .neq('user_id', user.id);
 
   if (levelFilter && levelFilter !== "All") {
-    query = query.ilike('level', levelFilter);
+    query = query.ilike('profile_target_languages.level', levelFilter);
   }
 
   if (languageFilter && languageFilter.trim() !== "") {
-    query = query.ilike('profile_target_languages.language', `%${languageFilter}%`);
+    query = query.ilike('profile_target_languages.language_id', `%${languageFilter}%`);
   }
 
   // edit for real logic
@@ -43,8 +45,8 @@ export async function GET(req: NextRequest) {
   const partners = (profiles || []).map((p: any) => ({
     id: p.user_id,
     first_name: p.first_name,
-    level: p.level,
-    target_language: p.profile_target_languages?.language || "None",
+    level: p.profile_target_languages[0]?.level,
+    target_language: p.profile_target_languages[0]?.language_id || "None",
   }));
   
   return NextResponse.json(partners);

--- a/language-learning/app/proxy.ts
+++ b/language-learning/app/proxy.ts
@@ -1,0 +1,19 @@
+import { type NextRequest } from "next/server"
+import { updateSession } from "@/lib/proxy"
+
+export async function proxy(request: NextRequest) {
+  return await updateSession(request)
+}
+
+export const config = {
+  matcher: [
+    /*
+     * Match all request paths except for the ones starting with:
+     * - _next/static (static files)
+     * - _next/image (image optimization files)
+     * - favicon.ico (favicon file)
+     * Feel free to modify this pattern to include more paths.
+     */
+    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+  ],
+}

--- a/language-learning/lib/proxy.ts
+++ b/language-learning/lib/proxy.ts
@@ -1,0 +1,65 @@
+import { createServerClient } from '@supabase/ssr'
+import { NextResponse, type NextRequest } from 'next/server'
+
+export async function updateSession(request: NextRequest) {
+  let supabaseResponse = NextResponse.next({
+    request,
+  })
+
+  // With Fluid compute, don't put this client in a global environment
+  // variable. Always create a new one on each request.
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return request.cookies.getAll()
+        },
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value }) => request.cookies.set(name, value))
+          supabaseResponse = NextResponse.next({
+            request,
+          })
+          cookiesToSet.forEach(({ name, value, options }) => supabaseResponse.cookies.set(name, value, options))
+        },
+      },
+    }
+  )
+
+  // Do not run code between createServerClient and
+  // supabase.auth.getClaims(). A simple mistake could make it very hard to debug
+  // issues with users being randomly logged out.
+
+  // IMPORTANT: If you remove getClaims() and you use server-side rendering
+  // with the Supabase client, your users may be randomly logged out.
+  const { data } = await supabase.auth.getClaims()
+
+  const user = data?.claims
+
+  if (
+    !user &&
+    !request.nextUrl.pathname.startsWith('/login') &&
+    !request.nextUrl.pathname.startsWith('/auth')
+  ) {
+    // no user, potentially respond by redirecting the user to the login page
+    const url = request.nextUrl.clone()
+    url.pathname = '/login'
+    return NextResponse.redirect(url)
+  }
+
+  // IMPORTANT: You *must* return the supabaseResponse object as it is. If you're
+  // creating a new response object with NextResponse.next() make sure to:
+  // 1. Pass the request in it, like so:
+  //    const myNewResponse = NextResponse.next({ request })
+  // 2. Copy over the cookies, like so:
+  //    myNewResponse.cookies.setAll(supabaseResponse.cookies.getAll())
+  // 3. Change the myNewResponse object to fit your needs, but avoid changing
+  //    the cookies!
+  // 4. Finally:
+  //    return myNewResponse
+  // If this is not done, you may be causing the browser and server to go out
+  // of sync and terminate the user's session prematurely!
+
+  return supabaseResponse
+}

--- a/language-learning/lib/supabaseClient.ts
+++ b/language-learning/lib/supabaseClient.ts
@@ -1,4 +1,4 @@
-import { createClient } from "@supabase/supabase-js";
+import { createBrowserClient } from '@supabase/ssr'
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
@@ -7,5 +7,5 @@ if (!supabaseUrl || !supabaseAnonKey) {
   throw new Error("Missing Supabase env vars. Check .env.local.");
 }
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+export const supabase = createBrowserClient(supabaseUrl, supabaseAnonKey);
 

--- a/language-learning/lib/supabaseServer.ts
+++ b/language-learning/lib/supabaseServer.ts
@@ -1,0 +1,27 @@
+import { createServerClient } from '@supabase/ssr'
+import { cookies } from 'next/headers'
+
+export async function createClient() {
+  const cookieStore = await cookies()
+
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll()
+        },
+        setAll(cookiesToSet) {
+          try {
+            cookiesToSet.forEach(({ name, value, options }) => cookieStore.set(name, value, options))
+          } catch {
+            // The `setAll` method was called from a Server Component.
+            // This can be ignored if you have middleware refreshing
+            // user sessions.
+          }
+        },
+      },
+    }
+  )
+}

--- a/language-learning/package-lock.json
+++ b/language-learning/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@supabase/ssr": "^0.8.0",
-        "@supabase/supabase-js": "^2.93.3",
+        "@supabase/supabase-js": "^2.95.3",
         "next": "16.1.4",
         "react": "19.2.3",
         "react-dom": "19.2.3"
@@ -1236,9 +1236,9 @@
       "license": "MIT"
     },
     "node_modules/@supabase/auth-js": {
-      "version": "2.93.3",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.93.3.tgz",
-      "integrity": "sha512-JdnkHZPKexVGSNONtu89RHU4bxz3X9kxx+f5ZnR5osoCIX+vs/MckwWRPZEybAEvlJXt5xjomDb3IB876QCxWQ==",
+      "version": "2.95.3",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.95.3.tgz",
+      "integrity": "sha512-vD2YoS8E2iKIX0F7EwXTmqhUpaNsmbU6X2R0/NdFcs02oEfnHyNP/3M716f3wVJ2E5XHGiTFXki6lRckhJ0Thg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -1248,9 +1248,9 @@
       }
     },
     "node_modules/@supabase/functions-js": {
-      "version": "2.93.3",
-      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.93.3.tgz",
-      "integrity": "sha512-qWO0gHNDm/5jRjROv/nv9L6sYabCWS1kzorOLUv3kqCwRvEJLYZga93ppJPrZwOgoZfXmJzvpjY8fODA4HQfBw==",
+      "version": "2.95.3",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.95.3.tgz",
+      "integrity": "sha512-uTuOAKzs9R/IovW1krO0ZbUHSJnsnyJElTXIRhjJTqymIVGcHzkAYnBCJqd7468Fs/Foz1BQ7Dv6DCl05lr7ig==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -1260,9 +1260,9 @@
       }
     },
     "node_modules/@supabase/postgrest-js": {
-      "version": "2.93.3",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.93.3.tgz",
-      "integrity": "sha512-+iJ96g94skO2e4clsRSmEXg22NUOjh9BziapsJSAvnB1grOBf/BA8vGtCHjNOA+Z6lvKXL1jwBqcL9+fS1W/Lg==",
+      "version": "2.95.3",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.95.3.tgz",
+      "integrity": "sha512-LTrRBqU1gOovxRm1vRXPItSMPBmEFqrfTqdPTRtzOILV4jPSueFz6pES5hpb4LRlkFwCPRmv3nQJ5N625V2Xrg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -1272,9 +1272,9 @@
       }
     },
     "node_modules/@supabase/realtime-js": {
-      "version": "2.93.3",
-      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.93.3.tgz",
-      "integrity": "sha512-gnYpcFzwy8IkezRP4CDbT5I8jOsiOjrWrqTY1B+7jIriXsnpifmlM6RRjLBm9oD7OwPG0/WksniGPdKW67sXOA==",
+      "version": "2.95.3",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.95.3.tgz",
+      "integrity": "sha512-D7EAtfU3w6BEUxDACjowWNJo/ZRo7sDIuhuOGKHIm9FHieGeoJV5R6GKTLtga/5l/6fDr2u+WcW/m8I9SYmaIw==",
       "license": "MIT",
       "dependencies": {
         "@types/phoenix": "^1.6.6",
@@ -1299,9 +1299,9 @@
       }
     },
     "node_modules/@supabase/storage-js": {
-      "version": "2.93.3",
-      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.93.3.tgz",
-      "integrity": "sha512-cw4qXiLrx3apglDM02Tx/w/stvFlrkKocC6vCvuFAz3JtVEl1zH8MUfDQDTH59kJAQVaVdbewrMWSoBob7REnA==",
+      "version": "2.95.3",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.95.3.tgz",
+      "integrity": "sha512-4GxkJiXI3HHWjxpC3sDx1BVrV87O0hfX+wvJdqGv67KeCu+g44SPnII8y0LL/Wr677jB7tpjAxKdtVWf+xhc9A==",
       "license": "MIT",
       "dependencies": {
         "iceberg-js": "^0.8.1",
@@ -1312,16 +1312,16 @@
       }
     },
     "node_modules/@supabase/supabase-js": {
-      "version": "2.93.3",
-      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.93.3.tgz",
-      "integrity": "sha512-paUqEqdBI9ztr/4bbMoCgeJ6M8ZTm2fpfjSOlzarPuzYveKFM20ZfDZqUpi9CFfYagYj5Iv3m3ztUjaI9/tM1w==",
+      "version": "2.95.3",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.95.3.tgz",
+      "integrity": "sha512-Fukw1cUTQ6xdLiHDJhKKPu6svEPaCEDvThqCne3OaQyZvuq2qjhJAd91kJu3PXLG18aooCgYBaB6qQz35hhABg==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/auth-js": "2.93.3",
-        "@supabase/functions-js": "2.93.3",
-        "@supabase/postgrest-js": "2.93.3",
-        "@supabase/realtime-js": "2.93.3",
-        "@supabase/storage-js": "2.93.3"
+        "@supabase/auth-js": "2.95.3",
+        "@supabase/functions-js": "2.95.3",
+        "@supabase/postgrest-js": "2.95.3",
+        "@supabase/realtime-js": "2.95.3",
+        "@supabase/storage-js": "2.95.3"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/language-learning/package.json
+++ b/language-learning/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@supabase/ssr": "^0.8.0",
-    "@supabase/supabase-js": "^2.93.3",
+    "@supabase/supabase-js": "^2.95.3",
     "next": "16.1.4",
     "react": "19.2.3",
     "react-dom": "19.2.3"


### PR DESCRIPTION
closes #88 
(probably test this after kun's refactoring. i did some local refactoring to test but i didn't push those files)

heavily referenced from https://supabase.com/docs/guides/auth/server-side/creating-a-client

file tracking: 
- adds files `app/proxy.ts`, `lib/proxy.ts`, `lib/supabaseServer.ts`, `app/api/discover/route.ts`
- modifies `lib/supbaseClient.ts` to import createBrowserClient from @supabase/ssr instead of old createClient (now reads from cookies managed by middleware)
- modifications to `package-lock.json` and `package.json` are from importing @supabase/supabase-js and @supabase/ssr helper packages

functional modifications: 
- after user request, middleware (proxy) sees the cookie, validates the session, and refreshes it if needed -> compare to previous client-side auth where browser checks local storage. this enables server-side validation (authenticated data fetching) before page reaches browser
- `app/api/discover/route.ts` now invokes the server createClient function to get the current user -> discover page can now exclude current user from appearing among recommended or searchable cards
- route file accommodates latest change of "level" field to profile_target_languages table