### PR TITLE
Implement Discover sorting

### DIFF
--- a/language-learning/app/api/discover/route.ts
+++ b/language-learning/app/api/discover/route.ts
@@ -5,12 +5,18 @@ type DiscoverRow = {
   user_id: string;
   language_id: number;
   level: string | null;
-  profiles: Array<{
+  profiles: {
+    first_name: string | null;
+    native_language: string | null;
+    updated_at: string | null;
+  } | Array<{
     first_name: string | null;
     native_language: string | null;
     updated_at: string | null;
   }> | null;
-  lang: Array<{
+  lang: {
+    name: string | null;
+  } | Array<{
     name: string | null;
   }> | null;
 };
@@ -18,7 +24,9 @@ type DiscoverRow = {
 type UserTargetRow = {
   language_id: number;
   level: string | null;
-  lang: Array<{
+  lang: {
+    name: string | null;
+  } | Array<{
     name: string | null;
   }> | null;
 };
@@ -43,10 +51,6 @@ const LEVEL_RANK: Record<string, number> = {
   advanced: 3,
 };
 
-function normalizeLanguage(value: string | null | undefined): string {
-  return (value ?? "").trim().toLowerCase();
-}
-
 function toDisplayLevel(level: string | null | undefined): string {
   if (!level) return "Beginner";
   return level.charAt(0).toUpperCase() + level.slice(1);
@@ -56,6 +60,11 @@ function rankLevel(level: string | null | undefined): number {
   return LEVEL_RANK[(level ?? "").toLowerCase()] ?? 0;
 }
 
+function firstRelation<T>(value: T | T[] | null | undefined): T | null {
+  if (!value) return null;
+  return Array.isArray(value) ? (value[0] ?? null) : value;
+}
+
 export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);
   const languageFilter = searchParams.get("language");
@@ -63,6 +72,10 @@ export async function GET(req: NextRequest) {
   const isRecommended = searchParams.get("recommended") === "true";
   const currentUserId = searchParams.get("currentUserId");
   const excludeUserIdsParam = searchParams.get("excludeUserIds");
+  const rawPage = Number.parseInt(searchParams.get("page") ?? "1", 10);
+  const rawPageSize = Number.parseInt(searchParams.get("pageSize") ?? "10", 10);
+  const page = Number.isFinite(rawPage) && rawPage > 0 ? rawPage : 1;
+  const pageSize = Number.isFinite(rawPageSize) && rawPageSize > 0 ? Math.min(rawPageSize, 50) : 10;
 
   let query = supabaseClient
     .from("profile_target_languages")
@@ -92,18 +105,20 @@ export async function GET(req: NextRequest) {
   const grouped = new Map<string, Candidate>();
   for (const row of (profiles as DiscoverRow[]) ?? []) {
     const existing = grouped.get(row.user_id);
+    const lang = firstRelation(row.lang);
+    const profile = firstRelation(row.profiles);
     const nextTarget: CandidateTarget = {
       language_id: row.language_id,
-      name: row.lang?.[0]?.name ?? "None",
+      name: lang?.name ?? "None",
       level: (row.level ?? "beginner").toLowerCase(),
     };
 
     if (!existing) {
       grouped.set(row.user_id, {
         id: row.user_id,
-        first_name: row.profiles?.[0]?.first_name ?? null,
-        native_language: row.profiles?.[0]?.native_language ?? null,
-        updated_at: row.profiles?.[0]?.updated_at ?? null,
+        first_name: profile?.first_name ?? null,
+        native_language: profile?.native_language ?? null,
+        updated_at: profile?.updated_at ?? null,
         targets: [nextTarget],
       });
       continue;
@@ -121,7 +136,7 @@ export async function GET(req: NextRequest) {
 
   if (currentUserId) excludedUserIds.add(currentUserId);
 
-  let userNativeNorm = "";
+  let userNativeLanguage = "";
   const userTargets = new Map<number, { name: string; level: string }>();
   const userTargetNameSet = new Set<string>();
 
@@ -132,7 +147,7 @@ export async function GET(req: NextRequest) {
       .eq("user_id", currentUserId)
       .maybeSingle();
 
-    userNativeNorm = normalizeLanguage(userProfile?.native_language ?? "");
+    userNativeLanguage = userProfile?.native_language ?? "";
 
     const { data: userTargetRows } = await supabaseClient
       .from("profile_target_languages")
@@ -140,33 +155,32 @@ export async function GET(req: NextRequest) {
       .eq("user_id", currentUserId);
 
     for (const row of (userTargetRows as UserTargetRow[]) ?? []) {
-      const targetName = row.lang?.[0]?.name ?? "";
-      const normalizedTargetName = normalizeLanguage(targetName);
+      const targetName = firstRelation(row.lang)?.name ?? "";
       userTargets.set(row.language_id, {
         name: targetName,
         level: (row.level ?? "beginner").toLowerCase(),
       });
-      if (normalizedTargetName) userTargetNameSet.add(normalizedTargetName);
+      if (targetName) userTargetNameSet.add(targetName);
     }
   }
 
-  const hasRankingContext = Boolean(userNativeNorm) && userTargets.size > 0;
+  const hasRankingContext = Boolean(userNativeLanguage) && userTargets.size > 0;
   const userTargetIdSet = new Set<number>([...userTargets.keys()]);
 
   const scored = [...grouped.values()]
     .filter((candidate) => !excludedUserIds.has(candidate.id))
     .map((candidate) => {
-      const candidateNativeNorm = normalizeLanguage(candidate.native_language);
+      const candidateNativeLanguage = candidate.native_language ?? "";
       const sharedTargets = candidate.targets.filter((target) =>
         userTargetIdSet.has(target.language_id),
       );
       const hasSharedTarget = sharedTargets.length > 0;
 
-      const candidateLearnsUserNative = userNativeNorm
-        ? candidate.targets.some((target) => normalizeLanguage(target.name) === userNativeNorm)
+      const candidateLearnsUserNative = userNativeLanguage
+        ? candidate.targets.some((target) => target.name === userNativeLanguage)
         : false;
-      const userLearnsCandidateNative = candidateNativeNorm
-        ? userTargetNameSet.has(candidateNativeNorm)
+      const userLearnsCandidateNative = candidateNativeLanguage
+        ? userTargetNameSet.has(candidateNativeLanguage)
         : false;
       const isMutualExchange = hasRankingContext && candidateLearnsUserNative && userLearnsCandidateNative;
 
@@ -220,6 +234,21 @@ export async function GET(req: NextRequest) {
   });
 
   const partners = scored.map(({ tier: _tier, levelDelta: _levelDelta, updated_at: _updatedAt, ...rest }) => rest);
-  const response = isRecommended ? partners.slice(0, 5) : partners;
-  return NextResponse.json(response);
+  if (isRecommended) {
+    return NextResponse.json(partners.slice(0, 5));
+  }
+
+  const total = partners.length;
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+  const safePage = Math.min(page, totalPages);
+  const start = (safePage - 1) * pageSize;
+  const items = partners.slice(start, start + pageSize);
+
+  return NextResponse.json({
+    items,
+    total,
+    page: safePage,
+    pageSize,
+    totalPages,
+  });
 }

--- a/language-learning/app/discover/DiscoverPagination.tsx
+++ b/language-learning/app/discover/DiscoverPagination.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+type DiscoverPaginationProps = {
+  page: number;
+  totalPages: number;
+  showingCount: number;
+  onPrev: () => void;
+  onNext: () => void;
+};
+
+export default function DiscoverPagination({
+  page,
+  totalPages,
+  showingCount,
+  onPrev,
+  onNext,
+}: DiscoverPaginationProps) {
+  return (
+    <div className="flex items-center justify-between px-1">
+      <p className="text-sm text-zinc-600">
+        page {`<${page}/${totalPages}>`} showing {showingCount} users
+      </p>
+      <div className="flex gap-2">
+        <button
+          onClick={onPrev}
+          disabled={page === 1}
+          className="px-3 py-1.5 text-sm border border-zinc-200 rounded-lg bg-white disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          Prev
+        </button>
+        <button
+          onClick={onNext}
+          disabled={page >= totalPages}
+          className="px-3 py-1.5 text-sm border border-zinc-200 rounded-lg bg-white disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  );
+}
+

--- a/language-learning/app/discover/page.tsx
+++ b/language-learning/app/discover/page.tsx
@@ -1,126 +1,34 @@
 'use client'
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { supabase } from "@/lib/supabaseClient";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
+import DiscoverPagination from "./DiscoverPagination";
+import { useDiscoverData } from "./useDiscoverData";
 
 const levels = ['All', 'Beginner', 'Intermediate', 'Advanced'];
 
 export default function DiscoverPage() {
-  const [recommended, setRecommended] = useState<any[]>([]);
-  const [filtered, setFiltered] = useState<any[]>([]);
-  const [currentUserId, setCurrentUserId] = useState<string | null>(null);
-  const [excludeUserIds, setExcludeUserIds] = useState<string[]>([]);
-
-  const[loadingRecs, setLoadingRecs] = useState(true);
-  const[loadingFilt, setLoadingFilt] = useState(true);
-
-  const [search, setSearch] = useState('');
-  const [levelFilter, setLevelFilter] = useState<string>('All');
-  const [languages, setLanguages] = useState<any[]>([]);
+  const {
+    recommended,
+    filtered,
+    loadingRecs,
+    loadingFilt,
+    search,
+    levelFilter,
+    languages,
+    page,
+    totalPages,
+    showingCount,
+    setSearch,
+    setLevelFilter,
+    resetFilters,
+    goPrevPage,
+    goNextPage,
+  } = useDiscoverData();
 
   const router = useRouter();
   const [connectingId, setConnectingId] = useState<string | null>(null);
-
-  useEffect(() => {
-    let mounted = true;
-    const loadCurrentUserAndExclusions = async () => {
-      try {
-        const { data } = await supabase.auth.getUser();
-        const me = data.user?.id ?? null;
-        if (!mounted) return;
-        setCurrentUserId(me);
-
-        if (!me) {
-          setExcludeUserIds([]);
-          return;
-        }
-
-        const excluded = new Set<string>([me]);
-
-        const { data: myParticipation } = await supabase
-          .from("conversation_participants")
-          .select("conversation_id")
-          .eq("user_id", me);
-
-        const conversationIds = (myParticipation || []).map((row: any) => row.conversation_id);
-        if (conversationIds.length > 0) {
-          const { data: partnerRows } = await supabase
-            .from("conversation_participants")
-            .select("user_id")
-            .in("conversation_id", conversationIds)
-            .neq("user_id", me);
-
-          for (const row of partnerRows || []) {
-            if (row.user_id) excluded.add(row.user_id);
-          }
-        }
-
-        setExcludeUserIds([...excluded]);
-      } catch (e) {
-        console.error(e);
-      }
-    };
-    loadCurrentUserAndExclusions();
-    return () => {
-      mounted = false;
-    };
-  }, []);
-
-  useEffect(() => {
-    const fetchRecs = async () => {
-      setLoadingRecs(true)
-      try {
-        const params = new URLSearchParams({ recommended: "true" });
-        if (currentUserId) params.set("currentUserId", currentUserId);
-        if (excludeUserIds.length > 0) params.set("excludeUserIds", excludeUserIds.join(","));
-        const res = await fetch(`/api/discover?${params.toString()}`);
-        if (res.ok) {
-          const data = await res.json();
-          setRecommended(data);
-        }
-      } catch (e) { console.error(e); }
-      setLoadingRecs(false);
-    };
-    fetchRecs();
-  }, [currentUserId, excludeUserIds]);
-
-  useEffect(() => {
-    const fetchLanguages = async () => {
-      try {
-        const { data, error } = await supabase
-          .from("languages")
-          .select("id, name")
-          .order("name", { ascending: true });
-
-        if (error) throw error;
-        setLanguages(data || []);
-      } catch (e) { console.error(e); }
-    };
-    fetchLanguages();
-  }, []);
-
-  useEffect(() => {
-    const timer = setTimeout(async () => {
-      setLoadingFilt(true)
-      try {
-        const params = new URLSearchParams({
-          language: search,
-          level: levelFilter,
-        });
-        if (currentUserId) params.set("currentUserId", currentUserId);
-        if (excludeUserIds.length > 0) params.set("excludeUserIds", excludeUserIds.join(","));
-        const url = `/api/discover?${params.toString()}`;
-        const res = await fetch(url);
-        if (res.ok) {
-          const data = await res.json();
-          setFiltered(data);
-        }
-      } catch (e) { console.error(e); }
-      setLoadingFilt(false)
-    }, 400);
-    return () => clearTimeout(timer);
-  }, [search, levelFilter, currentUserId, excludeUserIds]);
 
   async function handleConnect(partnerUserId: string) {
     try {
@@ -143,11 +51,6 @@ export default function DiscoverPage() {
       setConnectingId(null);
     }
   }
-
-  const resetFilters = () => {
-    setSearch('');
-    setLevelFilter('All');
-  };
 
   return (
     <div className="min-h-screen bg-white text-zinc-900 w-full">
@@ -262,29 +165,38 @@ export default function DiscoverPage() {
                 <p className="text-zinc-500 text-sm">No partners match your current filters.</p>
               </div>
             ) : (
-              <div className="grid grid-cols-1 gap-4">
-                {filtered.map((partner) => (
-                  <Link
-                    key={partner.id}
-                    href={`/profile/${partner.id}`}
-                    className="group border border-zinc-200 p-5 rounded-2xl hover:border-zinc-300 transition bg-white shadow-sm flex items-center justify-between cursor-pointer"
-                  >
-                    <div className="flex items-center gap-4">
-                      <div className="w-12 h-12 rounded-full bg-zinc-50 border border-zinc-200 flex items-center justify-center text-zinc-400 group-hover:bg-zinc-100 transition">
-                        <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M16 7a4 4 0 11-8 0 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" /></svg>
+              <div className="space-y-4">
+                <DiscoverPagination
+                  page={page}
+                  totalPages={totalPages}
+                  showingCount={showingCount}
+                  onPrev={goPrevPage}
+                  onNext={goNextPage}
+                />
+                <div className="grid grid-cols-1 gap-4">
+                  {filtered.map((partner) => (
+                    <Link
+                      key={partner.id}
+                      href={`/profile/${partner.id}`}
+                      className="group border border-zinc-200 p-5 rounded-2xl hover:border-zinc-300 transition bg-white shadow-sm flex items-center justify-between cursor-pointer"
+                    >
+                      <div className="flex items-center gap-4">
+                        <div className="w-12 h-12 rounded-full bg-zinc-50 border border-zinc-200 flex items-center justify-center text-zinc-400 group-hover:bg-zinc-100 transition">
+                          <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M16 7a4 4 0 11-8 0 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" /></svg>
+                        </div>
+                        <div>
+                          <p className="font-semibold text-zinc-900">{partner.first_name}</p>
+                          <p className="text-sm text-zinc-600">
+                            Learning {partner.target_language} • {partner.level}
+                          </p>
+                        </div>
                       </div>
-                      <div>
-                        <p className="font-semibold text-zinc-900">{partner.first_name}</p>
-                        <p className="text-sm text-zinc-600">
-                          Learning {partner.target_language} • {partner.level}
-                        </p>
+                      <div className="px-4 py-2 text-sm font-medium border border-zinc-200 rounded-xl bg-zinc-50 transition">
+                        View Profile
                       </div>
-                    </div>
-                    <div className="px-4 py-2 text-sm font-medium border border-zinc-200 rounded-xl bg-zinc-50 transition">
-                      View Profile
-                    </div>
-                  </Link>
-                ))}
+                    </Link>
+                  ))}
+                </div>
               </div>
             )}
           </div>

--- a/language-learning/app/discover/types.ts
+++ b/language-learning/app/discover/types.ts
@@ -1,0 +1,15 @@
+export type DiscoverPartner = {
+  id: string;
+  first_name: string | null;
+  level: string;
+  target_language: string;
+};
+
+export type DiscoverListResponse = {
+  items: DiscoverPartner[];
+  total: number;
+  page: number;
+  pageSize: number;
+  totalPages: number;
+};
+

--- a/language-learning/app/discover/useDiscoverData.ts
+++ b/language-learning/app/discover/useDiscoverData.ts
@@ -1,0 +1,186 @@
+'use client'
+
+import { useEffect, useState } from "react";
+import { supabase } from "@/lib/supabaseClient";
+import type { DiscoverListResponse, DiscoverPartner } from "./types";
+
+const PAGE_SIZE = 10;
+
+type ConversationIdRow = {
+  conversation_id: string;
+};
+
+type ConversationUserRow = {
+  user_id: string;
+};
+
+export function useDiscoverData() {
+  const [recommended, setRecommended] = useState<DiscoverPartner[]>([]);
+  const [filtered, setFiltered] = useState<DiscoverPartner[]>([]);
+  const [currentUserId, setCurrentUserId] = useState<string | null>(null);
+  const [excludeUserIds, setExcludeUserIds] = useState<string[]>([]);
+
+  const [loadingRecs, setLoadingRecs] = useState(true);
+  const [loadingFilt, setLoadingFilt] = useState(true);
+
+  const [search, setSearch] = useState("");
+  const [levelFilter, setLevelFilter] = useState<string>("All");
+  const [languages, setLanguages] = useState<Array<{ id: number; name: string }>>([]);
+
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const [showingCount, setShowingCount] = useState(0);
+
+  useEffect(() => {
+    let mounted = true;
+    const loadCurrentUserAndExclusions = async () => {
+      try {
+        const { data } = await supabase.auth.getUser();
+        const me = data.user?.id ?? null;
+        if (!mounted) return;
+        setCurrentUserId(me);
+
+        if (!me) {
+          setExcludeUserIds([]);
+          return;
+        }
+
+        const excluded = new Set<string>([me]);
+
+        const { data: myParticipation } = await supabase
+          .from("conversation_participants")
+          .select("conversation_id")
+          .eq("user_id", me);
+
+        const conversationIds = ((myParticipation as ConversationIdRow[]) ?? []).map(
+          (row) => row.conversation_id,
+        );
+
+        if (conversationIds.length > 0) {
+          const { data: partnerRows } = await supabase
+            .from("conversation_participants")
+            .select("user_id")
+            .in("conversation_id", conversationIds)
+            .neq("user_id", me);
+
+          for (const row of (partnerRows as ConversationUserRow[]) ?? []) {
+            if (row.user_id) excluded.add(row.user_id);
+          }
+        }
+
+        setExcludeUserIds([...excluded]);
+      } catch (e) {
+        console.error(e);
+      }
+    };
+    loadCurrentUserAndExclusions();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    const fetchRecs = async () => {
+      setLoadingRecs(true);
+      try {
+        const params = new URLSearchParams({ recommended: "true" });
+        if (currentUserId) params.set("currentUserId", currentUserId);
+        if (excludeUserIds.length > 0) params.set("excludeUserIds", excludeUserIds.join(","));
+        const res = await fetch(`/api/discover?${params.toString()}`);
+        if (res.ok) {
+          const data = (await res.json()) as DiscoverPartner[];
+          setRecommended(data);
+        }
+      } catch (e) {
+        console.error(e);
+      }
+      setLoadingRecs(false);
+    };
+    fetchRecs();
+  }, [currentUserId, excludeUserIds]);
+
+  useEffect(() => {
+    const fetchLanguages = async () => {
+      try {
+        const { data, error } = await supabase
+          .from("languages")
+          .select("id, name")
+          .order("name", { ascending: true });
+
+        if (error) throw error;
+        setLanguages((data as Array<{ id: number; name: string }>) || []);
+      } catch (e) {
+        console.error(e);
+      }
+    };
+    fetchLanguages();
+  }, []);
+
+  useEffect(() => {
+    setPage(1);
+  }, [search, levelFilter]);
+
+  useEffect(() => {
+    const timer = setTimeout(async () => {
+      setLoadingFilt(true);
+      try {
+        const params = new URLSearchParams({
+          language: search,
+          level: levelFilter,
+          page: String(page),
+          pageSize: String(PAGE_SIZE),
+        });
+        if (currentUserId) params.set("currentUserId", currentUserId);
+        if (excludeUserIds.length > 0) params.set("excludeUserIds", excludeUserIds.join(","));
+        const res = await fetch(`/api/discover?${params.toString()}`);
+        if (res.ok) {
+          const data = (await res.json()) as DiscoverListResponse | DiscoverPartner[];
+          const items = Array.isArray(data) ? data : data.items || [];
+          setFiltered(items);
+          setTotalPages(Array.isArray(data) ? 1 : data.totalPages || 1);
+          setShowingCount(items.length);
+          if (!Array.isArray(data) && typeof data.page === "number") {
+            setPage(data.page);
+          }
+        }
+      } catch (e) {
+        console.error(e);
+      }
+      setLoadingFilt(false);
+    }, 400);
+    return () => clearTimeout(timer);
+  }, [search, levelFilter, page, currentUserId, excludeUserIds]);
+
+  const resetFilters = () => {
+    setSearch("");
+    setLevelFilter("All");
+    setPage(1);
+  };
+
+  const goPrevPage = () => {
+    setPage((p) => Math.max(1, p - 1));
+  };
+
+  const goNextPage = () => {
+    setPage((p) => Math.min(totalPages, p + 1));
+  };
+
+  return {
+    recommended,
+    filtered,
+    loadingRecs,
+    loadingFilt,
+    search,
+    levelFilter,
+    languages,
+    page,
+    totalPages,
+    showingCount,
+    setSearch,
+    setLevelFilter,
+    resetFilters,
+    goPrevPage,
+    goNextPage,
+  };
+}
+


### PR DESCRIPTION
Closes #37

This PR updates Discover ordering to prioritize higher-value language exchange matches and removes users that should not appear. It also adds pagination for All Potential Matches, limiting results to 10 users per page with navigation for remaining users.

## Changes
- Adds deterministic ranking in Discover:
  - mutual exchange first (user's target language == partner's native/known language + partner's target language == user's native/known language)
  - shared target second (user's target == partner's target)
  - others last
  - higher-level candidates prioritized within shared-target ties
- Keeps Recommended list as the top 5 users from the same ranking.
- Excludes users who should not appear:
  - current user
  - users already in existing conversations
- Adds pagination for All Potential Matches:
  - 10 users per page
  - page indicator (`page <x/y> showing n users`)
  - Prev/Next navigation
- Applies filters before pagination and resets to page 1 when filters change.

## Acceptance Criteria
- [x] Sort discover: **mutual exchange -> shared target -> others** (higher-level tie-break).
- [x] Recommended = top 5 from the same ranking.
- [x] Exclude self + existing chat partners.
- [x] Paginate matches: 10/page with `Page <x/y> showing 10 users`.
- [x] Filters apply before pagination; empty state works.