### PR TITLE
Fixed browser tab title

### DIFF
--- a/language-learning/app/layout.tsx
+++ b/language-learning/app/layout.tsx
@@ -14,7 +14,7 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "Language Learner - Home",
+  title: "Language Learners",
   description: "Connect & Practice Conversation Language Skills",
 };
 


### PR DESCRIPTION
Closes #128 
This PR changes the browser tab title from "Language Learners - Home" to just Language Learners. This change was needed because the title indicated the user was on the Home page at all times when they actually weren't. No next steps needed. 
Test acceptance criteria:
- Browser tab title looks correct no matter the page.
- Nothing else affected or broken