### PR TITLE
Add functionality on Profiles

### DIFF
--- a/language-learning/app/profile/[userId]/page.tsx
+++ b/language-learning/app/profile/[userId]/page.tsx
@@ -195,7 +195,7 @@ export default function UserProfilePage() {
 
   const withAction = async (
     label: "send" | "accept" | "deny" | "cancel" | "unfriend",
-    fn: () => Promise<void>
+    fn: () => Promise<unknown>
   ) => {
     setActionLoading(label);
     setActionError(null);

--- a/language-learning/tsconfig.json
+++ b/language-learning/tsconfig.json
@@ -30,5 +30,11 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": [
+    "node_modules",
+    "playwright.config.ts",
+    "e2e/**",
+    "playwright-report/**",
+    "test-results/**"
+  ]
 }


### PR DESCRIPTION
Add a new button to the public profile that mirrors the status of current "relationship":
If currently friends, then displays "message" and "unfriend"
If not friends and not requested to be a friend, then displays "connect"
If not friends and have requested to be a friend, then displays "cancel [the request]"

Builds to the goal of not allowing people to message others willy nilly, needs consent.

Testing methods:
Go on Vercel deployment or localhost, and verify the acceptance criteria. To test friend requests, use two accounts -one to request, one to accept. Check that a user needs permission to connect with another user, and cannot message before, and that once connected, the button UI will change.

## Acceptance Criteria:
- [x] Show correct primary actions on public profile based on relationship:
  - [x] Friends → show **Message** + **Unfriend**
  - [x] Not friends + no request → show **Connect**
  - [x] Not friends + request pending → show **Cancel Request**
- [x] Clicking **Message** opens chat (friends only)
- [x] Clicking **Unfriend** removes friendship + updates UI to **Connect**
- [x] Clicking **Connect** sends friend request + updates UI to **Cancel Request**
- [x] Clicking **Cancel Request** withdraws request + updates UI to **Connect**
- [x] Block messaging when not friends + show clear “connect to message” notice
