### PR TITLE
kun - Added ProfileAPI

### DIFF
--- a/language-learning/app/api/auth/signout/route.ts
+++ b/language-learning/app/api/auth/signout/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabaseServer";
+
+export async function POST() {
+  const supabase = await createClient();
+  await supabase.auth.signOut();
+  return NextResponse.json({ success: true });
+}

--- a/language-learning/app/api/friends/action/route.ts
+++ b/language-learning/app/api/friends/action/route.ts
@@ -20,9 +20,10 @@ export async function POST(req: NextRequest) {
           recipientId: targetUserId 
         });
         return NextResponse.json({ success: true, request_id: newReq.id });
-      case "accept":
-        await friends.acceptFriendRequest({ requestId: request_id });
-        break;
+      case "accept": {
+        const conversationId = await friends.acceptFriendRequest({ requestId: request_id });
+        return NextResponse.json({ success: true, conversationId });
+      }
       case "cancel":
         console.log("Cancelling Request ID:", request_id);
         if (!request_id) throw new Error("Server received null request_id for cancel");

--- a/language-learning/app/api/friends/status/route.ts
+++ b/language-learning/app/api/friends/status/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabaseServer";
+import { createFriendService } from "@/utils/friends/friendService";
+
+export async function GET(req: NextRequest) {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  const { searchParams } = new URL(req.url);
+  const targetUserId = searchParams.get("targetUserId");
+
+  if (!targetUserId) {
+    return NextResponse.json({ error: "targetUserId is required" }, { status: 400 });
+  }
+
+  if (!user) {
+    return NextResponse.json({ viewerId: null, status: null });
+  }
+
+  const friends = createFriendService(supabase);
+  try {
+    const status = await friends.getRelationshipStatus({ viewerId: user.id, otherUserId: targetUserId });
+    return NextResponse.json({ viewerId: user.id, status });
+  } catch (e: any) {
+    return NextResponse.json({ error: e?.message || "Failed to load relationship status" }, { status: 500 });
+  }
+}

--- a/language-learning/app/api/friends/unfriend/route.ts
+++ b/language-learning/app/api/friends/unfriend/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabaseServer";
+import { createFriendService } from "@/utils/friends/friendService";
+
+export async function POST(req: NextRequest) {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { otherUserId } = await req.json();
+  if (!otherUserId) {
+    return NextResponse.json({ error: "otherUserId is required" }, { status: 400 });
+  }
+
+  const friends = createFriendService(supabase);
+  try {
+    await friends.unfriend({ otherUserId });
+    return NextResponse.json({ success: true });
+  } catch (e: any) {
+    return NextResponse.json({ error: e?.message || "Failed to unfriend" }, { status: 500 });
+  }
+}

--- a/language-learning/app/api/profile/[userId]/route.ts
+++ b/language-learning/app/api/profile/[userId]/route.ts
@@ -1,0 +1,78 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabaseServer";
+
+type TargetLanguage = {
+  name: string;
+  level: "Beginner" | "Intermediate" | "Advanced" | null;
+};
+
+type Profile = {
+  firstName?: string | null;
+  lastName?: string | null;
+  bio?: string | null;
+  targetLanguages: TargetLanguage[];
+  profilePicture?: string | null;
+  nativeLanguage?: string | null;
+};
+
+function levelToDisplay(level: string | null | undefined): TargetLanguage["level"] {
+  if (!level) return null;
+  const lower = level.toLowerCase();
+  if (lower === "intermediate") return "Intermediate";
+  if (lower === "advanced") return "Advanced";
+  return "Beginner";
+}
+
+export async function GET(
+    _req: NextRequest, 
+    { params }: { params: Promise<{ userId: string }> }
+    // context: { params: { userId: string } }
+) {
+  const supabase = await createClient();
+  const { userId } = await params;
+
+  const { data: profileData, error: profileError } = await supabase
+    .from("profiles")
+    .select("first_name, last_name, bio, native_language, profile_picture_url")
+    .eq("user_id", userId)
+    .single();
+
+  if (profileError) {
+    const status = profileError.code === "PGRST116" ? 404 : 500;
+    return NextResponse.json(
+      { error: profileError.message || "Failed to load profile" },
+      { status }
+    );
+  }
+
+  const { data: targetLanguagesData, error: targetLanguagesError } = await supabase
+    .from("profile_target_languages")
+    .select("level, languages!profile_target_languages_language_id_fkey(name)")
+    .eq("user_id", userId);
+
+  if (targetLanguagesError) {
+    return NextResponse.json(
+      { error: targetLanguagesError.message || "Failed to load target languages" },
+      { status: 500 }
+    );
+  }
+
+  const targetLanguages: TargetLanguage[] = (targetLanguagesData ?? [])
+    .map((row: any) => {
+      const name = row?.languages?.name ?? null;
+      if (!name) return null;
+      return { name, level: levelToDisplay(row.level) };
+    })
+    .filter(Boolean) as TargetLanguage[];
+
+  const profile: Profile = {
+    firstName: profileData.first_name,
+    lastName: profileData.last_name,
+    bio: profileData.bio,
+    targetLanguages,
+    profilePicture: profileData.profile_picture_url,
+    nativeLanguage: profileData.native_language,
+  };
+
+  return NextResponse.json({ profile });
+}

--- a/language-learning/app/api/profile/delete/route.ts
+++ b/language-learning/app/api/profile/delete/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabaseServer";
+
+export async function POST() {
+  const supabase = await createClient();
+  const { data: { user }, error: userError } = await supabase.auth.getUser();
+  if (!user || userError) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { error: deleteAuthError } = await supabase.rpc("delete_user_account", { user_uuid: user.id });
+
+  if (deleteAuthError) {
+    return NextResponse.json(
+      { error: deleteAuthError.message || "Delete account failed", code: deleteAuthError.code },
+      { status: 500 }
+    );
+  }
+
+  await supabase.auth.signOut();
+
+  return NextResponse.json({ success: true });
+}

--- a/language-learning/app/api/profile/languages/route.ts
+++ b/language-learning/app/api/profile/languages/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabaseServer";
+
+export async function GET() {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("languages")
+    .select("id, name")
+    .order("name", { ascending: true });
+
+  if (error) {
+    return NextResponse.json({ error: error.message || "Failed to load languages" }, { status: 500 });
+  }
+
+  return NextResponse.json({ languages: data ?? [] });
+}

--- a/language-learning/app/api/profile/me/route.ts
+++ b/language-learning/app/api/profile/me/route.ts
@@ -1,0 +1,180 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabaseServer";
+
+type TargetLanguage = {
+  name: string;
+  level: "Beginner" | "Intermediate" | "Advanced" | null;
+};
+
+type Profile = {
+  firstName?: string | null;
+  lastName?: string | null;
+  bio?: string | null;
+  targetLanguages: TargetLanguage[];
+  profilePicture?: string | null;
+  nativeLanguage?: string | null;
+};
+
+type ProfilePayload = {
+  firstName?: string | null;
+  lastName?: string | null;
+  bio?: string | null;
+  nativeLanguage?: string | null;
+  targetLanguages?: Array<{ name: string; level: string }>;
+};
+
+function levelToDisplay(level: string | null | undefined): TargetLanguage["level"] {
+  if (!level) return null;
+  const lower = level.toLowerCase();
+  if (lower === "intermediate") return "Intermediate";
+  if (lower === "advanced") return "Advanced";
+  return "Beginner";
+}
+
+export async function GET() {
+  const supabase = await createClient();
+  const { data: { user }, error: authError } = await supabase.auth.getUser();
+  if (!user || authError) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { data: profileData, error: profileError } = await supabase
+    .from("profiles")
+    .select("first_name, last_name, bio, native_language, profile_picture_url")
+    .eq("user_id", user.id)
+    .single();
+
+  if (profileError && profileError.code !== "PGRST116") {
+    return NextResponse.json(
+      { error: profileError.message || "Failed to load profile" },
+      { status: 500 }
+    );
+  }
+
+  const { data: targetLanguagesData, error: targetLanguagesError } = await supabase
+    .from("profile_target_languages")
+    .select("level, languages!profile_target_languages_language_id_fkey(name)")
+    .eq("user_id", user.id);
+
+  if (targetLanguagesError) {
+    return NextResponse.json(
+      { error: targetLanguagesError.message || "Failed to load target languages" },
+      { status: 500 }
+    );
+  }
+
+  const targetLanguages: TargetLanguage[] = (targetLanguagesData ?? [])
+    .map((row: any) => {
+      const name = row?.languages?.name ?? null;
+      if (!name) return null;
+      return { name, level: levelToDisplay(row.level) };
+    })
+    .filter(Boolean) as TargetLanguage[];
+
+  const profile: Profile = {
+    firstName: profileData?.first_name ?? null,
+    lastName: profileData?.last_name ?? null,
+    bio: profileData?.bio ?? null,
+    targetLanguages,
+    profilePicture: profileData?.profile_picture_url ?? null,
+    nativeLanguage: profileData?.native_language ?? null,
+  };
+
+  return NextResponse.json({ profile });
+}
+
+export async function PUT(req: NextRequest) {
+  const supabase = await createClient();
+  const { data: { user }, error: authError } = await supabase.auth.getUser();
+  if (!user || authError) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const payload = (await req.json()) as ProfilePayload;
+
+  const { data: existingProfile } = await supabase
+    .from("profiles")
+    .select("email")
+    .eq("user_id", user.id)
+    .single();
+
+  let email: string | null = existingProfile?.email || null;
+  if (!email) {
+    email = user.email || null;
+  }
+
+  const { error: profileError } = await supabase
+    .from("profiles")
+    .upsert(
+      {
+        user_id: user.id,
+        email,
+        first_name: payload.firstName?.trim() || null,
+        last_name: payload.lastName?.trim() || null,
+        bio: payload.bio || null,
+        native_language: payload.nativeLanguage?.trim() || null,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: "user_id" }
+    );
+
+  if (profileError) {
+    return NextResponse.json({ error: profileError.message || "Profile update failed" }, { status: 500 });
+  }
+
+  const cleaned = (payload.targetLanguages ?? [])
+    .map((t) => ({ name: t.name.trim(), level: t.level }))
+    .filter((t) => !!t.name);
+
+  const { error: delErr } = await supabase
+    .from("profile_target_languages")
+    .delete()
+    .eq("user_id", user.id);
+
+  if (delErr) {
+    return NextResponse.json({ error: delErr.message || "Failed to update target languages" }, { status: 500 });
+  }
+
+  if (cleaned.length === 0) {
+    return NextResponse.json({ success: true });
+  }
+
+  const seen = new Set<string>();
+  const deduped = cleaned.filter((t) => {
+    const k = t.name.toLowerCase();
+    if (seen.has(k)) return false;
+    seen.add(k);
+    return true;
+  });
+
+  const names = deduped.map((t) => t.name);
+  const { data: langRows, error: langSelectError } = await supabase
+    .from("languages")
+    .select("id, name")
+    .in("name", names);
+
+  if (langSelectError) {
+    return NextResponse.json({ error: langSelectError.message || "Failed to resolve languages" }, { status: 500 });
+  }
+
+  const idByName = new Map<string, number>();
+  (langRows ?? []).forEach((r: any) => idByName.set(String(r.name), Number(r.id)));
+
+  const missing = names.filter((n) => !idByName.has(n));
+  if (missing.length > 0) {
+    return NextResponse.json({ error: `Selected language(s) not found: ${missing.join(", ")}` }, { status: 400 });
+  }
+
+  const inserts = deduped.map((t) => ({
+    user_id: user.id,
+    language_id: idByName.get(t.name)!,
+    level: t.level,
+  }));
+
+  const { error: insErr } = await supabase.from("profile_target_languages").insert(inserts);
+  if (insErr) {
+    return NextResponse.json({ error: insErr.message || "Failed to update target languages" }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/language-learning/app/api/profile/start-conversation/route.ts
+++ b/language-learning/app/api/profile/start-conversation/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabaseServer";
+
+export async function POST(req: NextRequest) {
+  const supabase = await createClient();
+  const { data: { user }, error: authError } = await supabase.auth.getUser();
+  if (!user || authError) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { partnerId } = await req.json();
+  if (!partnerId) {
+    return NextResponse.json({ error: "partnerId is required" }, { status: 400 });
+  }
+
+  const { data, error } = await supabase.rpc("start_conversation_no_dupe", {
+    partner_id: partnerId,
+  });
+
+  if (error) {
+    return NextResponse.json({ error: error.message || "Failed to start conversation" }, { status: 500 });
+  }
+
+  return NextResponse.json({ conversationId: data as string });
+}

--- a/language-learning/app/profile/[userId]/page.tsx
+++ b/language-learning/app/profile/[userId]/page.tsx
@@ -4,20 +4,7 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useRouter, useParams } from "next/navigation";
-import { supabase } from "@/lib/supabaseClient";
-import { createFriendService } from "@/utils/friends/friendService";
 import type { RelationshipStatus } from "@/utils/friends/friendTypes";
-
-// Helper function to convert database level to display format
-function levelToDisplay(
-  level: string | null | undefined
-): "Beginner" | "Intermediate" | "Advanced" | null {
-  if (!level) return null;
-  const lower = level.toLowerCase();
-  if (lower === "intermediate") return "Intermediate";
-  if (lower === "advanced") return "Advanced";
-  return "Beginner";
-}
 
 type TargetLanguage = {
   name: string;
@@ -28,7 +15,7 @@ type Profile = {
   firstName?: string | null;
   lastName?: string | null;
   bio?: string | null;
-  targetLanguages: TargetLanguage[]; // ✅ multiple
+  targetLanguages: TargetLanguage[];
   profilePicture?: string | null;
   nativeLanguage?: string | null;
 };
@@ -38,72 +25,13 @@ type LoadState<T> =
   | { status: "error"; message: string }
   | { status: "success"; data: T };
 
-async function getUserId(): Promise<string | null> {
-  try {
-    const {
-      data: { user },
-      error: authError,
-    } = await supabase.auth.getUser();
-    if (!authError && user) return user.id;
-  } catch {
-    // ignore auth errors
-  }
-  return null;
-}
-
 async function fetchUserProfile(userId: string): Promise<Profile> {
-  // Fetch profile data
-  const { data: profileData, error: profileError } = await supabase
-    .from("profiles")
-    .select("first_name, last_name, bio, native_language, profile_picture_url")
-    .eq("user_id", userId)
-    .single();
-
-  if (profileError) {
-    if (profileError.code === "PGRST116") throw new Error("Profile not found");
-    const errorMessage =
-      profileError.message || `Supabase error: ${profileError.code || "Unknown"}`;
-    const enhancedError = new Error(errorMessage);
-    (enhancedError as any).code = profileError.code;
-    (enhancedError as any).details = profileError.details;
-    throw enhancedError;
+  const res = await fetch(`/api/profile/${encodeURIComponent(userId)}`);
+  const body = await res.json();
+  if (!res.ok) {
+    throw new Error(body?.error || "Profile not found");
   }
-
-  // Fetch ALL target languages
-  const { data: targetLanguagesData, error: targetLanguagesError } = await supabase
-    .from("profile_target_languages")
-    .select("level, languages!profile_target_languages_language_id_fkey(name)")
-    .eq("user_id", userId);
-
-  if (targetLanguagesError) {
-    const errorMessage =
-      targetLanguagesError.message ||
-      `Supabase error: ${targetLanguagesError.code || "Unknown"}`;
-    const enhancedError = new Error(errorMessage);
-    (enhancedError as any).code = targetLanguagesError.code;
-    (enhancedError as any).details = targetLanguagesError.details;
-    throw enhancedError;
-  }
-
-  const targetLanguages: TargetLanguage[] = (targetLanguagesData ?? [])
-    .map((row: any) => {
-      const name = row?.languages?.name ?? null;
-      if (!name) return null;
-      return {
-        name,
-        level: levelToDisplay(row.level),
-      };
-    })
-    .filter(Boolean) as TargetLanguage[];
-
-  return {
-    firstName: profileData.first_name,
-    lastName: profileData.last_name,
-    bio: profileData.bio,
-    targetLanguages,
-    profilePicture: profileData.profile_picture_url,
-    nativeLanguage: profileData.native_language,
-  };
+  return body.profile as Profile;
 }
 
 export default function UserProfilePage() {
@@ -162,25 +90,12 @@ export default function UserProfilePage() {
     (async () => {
       setStatusLoading(true);
       try {
-        const vid = await getUserId();
+        const res = await fetch(`/api/friends/status?targetUserId=${encodeURIComponent(userId)}`);
+        const body = await res.json();
         if (cancelled) return;
-        setViewerId(vid);
 
-        if (!vid) {
-          setRelStatus(null);
-          return;
-        }
-        if (vid === userId) {
-          setRelStatus({ kind: "self" });
-          return;
-        }
-
-        const friends = createFriendService(supabase);
-        const status = await friends.getRelationshipStatus({
-          viewerId: vid,
-          otherUserId: userId,
-        });
-        if (!cancelled) setRelStatus(status);
+        setViewerId(body?.viewerId ?? null);
+        setRelStatus(body?.status ?? null);
       } catch (e) {
         if (!cancelled) {
           console.error("Relationship status error:", e);
@@ -197,16 +112,15 @@ export default function UserProfilePage() {
   }, [userId]);
 
   const refreshStatus = async () => {
-    if (!viewerId || viewerId === userId) {
-      setRelStatus(viewerId === userId ? { kind: "self" } : null);
-      return;
+    try {
+      const res = await fetch(`/api/friends/status?targetUserId=${encodeURIComponent(userId)}`);
+      const body = await res.json();
+      setViewerId(body?.viewerId ?? null);
+      setRelStatus(body?.status ?? null);
+    } catch (e) {
+      console.error("Relationship status error:", e);
+      setRelStatus(null);
     }
-    const friends = createFriendService(supabase);
-    const status = await friends.getRelationshipStatus({
-      viewerId,
-      otherUserId: userId,
-    });
-    setRelStatus(status);
   };
 
   const withAction = async (
@@ -231,37 +145,70 @@ export default function UserProfilePage() {
       setActionError("Please sign in to send friend requests.");
       return;
     }
-    const friends = createFriendService(supabase);
-    await withAction("send", () =>
-      friends.sendFriendRequest({ requesterId: viewerId, recipientId: userId })
-    );
+    await withAction("send", async () => {
+      const res = await fetch("/api/friends/action", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ targetUserId: userId, action: "send" }),
+      });
+      const body = await res.json();
+      if (!res.ok) throw new Error(body?.error || "Failed to send request");
+    });
   }
 
   async function handleAccept(requestId?: string) {
     if (!viewerId || !requestId) return;
-    const friends = createFriendService(supabase);
     await withAction("accept", async () => {
-      const conversationId = await friends.acceptFriendRequest({ requestId });
-      router.push(`/chats?c=${encodeURIComponent(conversationId)}`);
+      const res = await fetch("/api/friends/action", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ targetUserId: userId, action: "accept", request_id: requestId }),
+      });
+      const body = await res.json();
+      if (!res.ok) throw new Error(body?.error || "Failed to accept request");
+      if (body?.conversationId) {
+        router.push(`/chats?c=${encodeURIComponent(body.conversationId)}`);
+      }
     });
   }
 
   async function handleDeny(requestId?: string) {
     if (!viewerId || !requestId) return;
-    const friends = createFriendService(supabase);
-    await withAction("deny", () => friends.denyFriendRequest({ requestId }));
+    await withAction("deny", async () => {
+      const res = await fetch("/api/friends/action", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ targetUserId: userId, action: "deny", request_id: requestId }),
+      });
+      const body = await res.json();
+      if (!res.ok) throw new Error(body?.error || "Failed to deny request");
+    });
   }
 
   async function handleCancel(requestId?: string) {
     if (!viewerId || !requestId) return;
-    const friends = createFriendService(supabase);
-    await withAction("cancel", () => friends.cancelFriendRequest({ requestId }));
+    await withAction("cancel", async () => {
+      const res = await fetch("/api/friends/action", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ targetUserId: userId, action: "cancel", request_id: requestId }),
+      });
+      const body = await res.json();
+      if (!res.ok) throw new Error(body?.error || "Failed to cancel request");
+    });
   }
 
   async function handleUnfriend() {
     if (!viewerId) return;
-    const friends = createFriendService(supabase);
-    await withAction("unfriend", () => friends.unfriend({ otherUserId: userId }));
+    await withAction("unfriend", async () => {
+      const res = await fetch("/api/friends/unfriend", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ otherUserId: userId }),
+      });
+      const body = await res.json();
+      if (!res.ok) throw new Error(body?.error || "Failed to unfriend");
+    });
   }
 
   async function handleMessage() {
@@ -270,13 +217,15 @@ export default function UserProfilePage() {
       setMessaging(true);
       setError(null);
 
-      const { data, error } = await supabase.rpc("start_conversation_no_dupe", {
-        partner_id: userId,
+      const res = await fetch("/api/profile/start-conversation", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ partnerId: userId }),
       });
+      const body = await res.json();
+      if (!res.ok) throw new Error(body?.error || "Failed to start conversation");
 
-      if (error) throw error;
-
-      const conversationId = data as string;
+      const conversationId = body.conversationId as string;
       router.push(`/chats?c=${encodeURIComponent(conversationId)}`);
     } catch (e) {
       console.error(e);

--- a/language-learning/app/profile/edit/page.tsx
+++ b/language-learning/app/profile/edit/page.tsx
@@ -3,21 +3,11 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
-import { supabase } from "@/lib/supabaseClient";
 
 // Database stores lowercase values
 type LevelDB = "beginner" | "intermediate" | "advanced";
 // UI displays capitalized values
 type LevelDisplay = "Beginner" | "Intermediate" | "Advanced";
-
-// Helper functions to convert between database and display formats
-function levelToDisplay(level: LevelDB | string | null | undefined): LevelDisplay {
-  if (!level) return "Beginner";
-  const lower = level.toLowerCase();
-  if (lower === "intermediate") return "Intermediate";
-  if (lower === "advanced") return "Advanced";
-  return "Beginner";
-}
 
 function levelToDB(level: LevelDisplay): LevelDB {
   const lower = level.toLowerCase();
@@ -60,174 +50,37 @@ type ProfileAPI = {
   targetLanguages: { name: string; level: LevelDB }[];
 };
 
-async function getUserId(): Promise<string> {
-  try {
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
-    if (!authError && user) {
-      return user.id;
-    }
-  } catch (e) {
-    // Ignore auth errors in test mode
-  }
-  // TEST MODE: Use a test user ID when not authenticated
-  return "test-user-id";
-}
-
 async function fetchLanguages(): Promise<LanguageOption[]> {
-  const { data, error } = await supabase
-    .from("languages")
-    .select("id, name")
-    .order("name", { ascending: true });
-
-  if (error) throw error;
-  return (data ?? []) as LanguageOption[];
+  const res = await fetch("/api/profile/languages");
+  const body = await res.json();
+  if (!res.ok) throw new Error(body?.error || "Failed to load languages");
+  return (body.languages ?? []) as LanguageOption[];
 }
 
 async function fetchMyProfile(): Promise<ProfileDisplay> {
-  const userId = await getUserId();
-  console.log("Fetching profile for user:", userId);
+  const res = await fetch("/api/profile/me");
+  const body = await res.json();
+  if (!res.ok) throw new Error(body?.error || "Failed to load profile");
 
-  const { data: profileData, error: profileError } = await supabase
-    .from("profiles")
-    .select("first_name, last_name, bio, native_language")
-    .eq("user_id", userId)
-    .single();
+  const data = body.profile as ProfileDisplay;
 
-  console.log("Profile fetch result:", { profileData, profileError });
-
-  if (profileError) {
-    // If no profile exists, return empty profile
-    if (profileError.code === 'PGRST116') {
-      console.log("No profile found, returning empty profile");
-      return {
-        firstName: "",
-        lastName: "",
-        bio: "",
-        nativeLanguage: "",
-        targetLanguages: [],
-      };
-    }
-    console.error("Profile fetch error:", profileError);
-    throw profileError;
-  }
-
-  // Fetch target languages from separate table
-  const { data: targetLanguagesData, error: targetLanguagesError } = await supabase
-    .from("profile_target_languages")
-    .select("level, languages!profile_target_languages_language_id_fkey(name)")
-    .eq("user_id", userId);
-
-  console.log("Target languages fetch result:", { targetLanguagesData, targetLanguagesError });
-  if (targetLanguagesError) console.error("Target languages fetch error:", targetLanguagesError);
-
-  const targetLanguages: TargetLanguageFormItem[] = (targetLanguagesData ?? [])
-    .map((row: any) => {
-      const name = row?.languages?.name ?? "";
-      if (!name) return null;
-      return { name, level: levelToDisplay(row.level) };
-    })
-    .filter(Boolean) as TargetLanguageFormItem[];
-
-  const result: ProfileDisplay = {
-    firstName: profileData.first_name || "",
-    lastName: profileData.last_name || "",
-    bio: profileData.bio || "",
-    nativeLanguage: profileData.native_language || "",
-    targetLanguages,
+  return {
+    firstName: data.firstName || "",
+    lastName: data.lastName || "",
+    bio: data.bio || "",
+    nativeLanguage: data.nativeLanguage || "",
+    targetLanguages: data.targetLanguages ?? [],
   };
-
-  console.log("Returning profile data:", result);
-  return result;
 }
 
 async function saveMyProfile(payload: ProfileAPI): Promise<void> {
-  const userId = await getUserId();
-
-  // Get existing profile to preserve email, or get email from auth user
-  const { data: existingProfile } = await supabase
-    .from("profiles")
-    .select("email")
-    .eq("user_id", userId)
-    .single();
-
-  let email: string | null = existingProfile?.email || null;
-  if (!email) {
-    try {
-      const {
-        data: { user },
-      } = await supabase.auth.getUser();
-      email = user?.email || null;
-    } catch {
-      // ignore
-    }
-  }
-
-  // Upsert profile
-  const { error: profileError } = await supabase
-    .from("profiles")
-    .upsert(
-      {
-        user_id: userId,
-        email: email,
-        first_name: payload.firstName?.trim() || null,
-        last_name: payload.lastName?.trim() || null,
-        bio: payload.bio || null,
-        native_language: payload.nativeLanguage?.trim() || null,
-        updated_at: new Date().toISOString(),
-      },
-      { onConflict: "user_id" }
-    );
-
-  if (profileError) throw profileError;
-
-  // Replace ALL target languages
-  const cleaned = (payload.targetLanguages ?? [])
-    .map((t) => ({ name: t.name.trim(), level: t.level }))
-    .filter((t) => !!t.name);
-
-  const { error: delErr } = await supabase
-    .from("profile_target_languages")
-    .delete()
-    .eq("user_id", userId);
-
-  if (delErr) throw delErr;
-
-  if (cleaned.length === 0) return;
-
-  // Dedupe by language name
-  const seen = new Set<string>();
-  const deduped = cleaned.filter((t) => {
-    const k = t.name.toLowerCase();
-    if (seen.has(k)) return false;
-    seen.add(k);
-    return true;
+  const res = await fetch("/api/profile/me", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
   });
-
-  // Fetch language ids in one query
-  const names = deduped.map((t) => t.name);
-  const { data: langRows, error: langSelectError } = await supabase
-    .from("languages")
-    .select("id, name")
-    .in("name", names);
-
-  if (langSelectError) throw langSelectError;
-
-  const idByName = new Map<string, number>();
-  (langRows ?? []).forEach((r: any) => idByName.set(String(r.name), Number(r.id)));
-
-  const missing = names.filter((n) => !idByName.has(n));
-  if (missing.length > 0) {
-    throw new Error(`Selected language(s) not found in languages table: ${missing.join(", ")}`);
-  }
-
-  const inserts = deduped.map((t) => ({
-    user_id: userId,
-    language_id: idByName.get(t.name)!,
-    level: t.level,
-  }));
-
-  const { error: insErr } = await supabase.from("profile_target_languages").insert(inserts);
-  if (insErr) throw insErr;
+  const body = await res.json();
+  if (!res.ok) throw new Error(body?.error || "Failed to save profile");
 }
 
 export default function EditProfilePage() {

--- a/language-learning/app/profile/page.tsx
+++ b/language-learning/app/profile/page.tsx
@@ -4,18 +4,6 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { supabase } from "@/lib/supabaseClient";
-
-// Helper function to convert database level to display format
-function levelToDisplay(
-  level: string | null | undefined
-): "Beginner" | "Intermediate" | "Advanced" | null {
-  if (!level) return null;
-  const lower = level.toLowerCase();
-  if (lower === "intermediate") return "Intermediate";
-  if (lower === "advanced") return "Advanced";
-  return "Beginner";
-}
 
 type TargetLanguage = {
   name: string;
@@ -36,85 +24,14 @@ type LoadState<T> =
   | { status: "error"; message: string }
   | { status: "success"; data: T };
 
-async function getUserId(): Promise<string> {
-  try {
-    const { data, error: authError } = await supabase.auth.getSession();
-    if (!authError && data.session?.user) {
-      return data.session.user.id;
-    }
-  } catch {
-    // Ignore auth errors in test mode
-  }
-  // TEST MODE: Use a valid UUID when not authenticated
-  return "00000000-0000-0000-0000-000000000000";
-}
-
 async function fetchMyProfile(): Promise<Profile> {
   try {
-    const userId = await getUserId();
-
-    // Fetch profile data
-    const { data: profileData, error: profileError } = await supabase
-      .from("profiles")
-      .select("first_name, last_name, bio, native_language, profile_picture_url")
-      .eq("user_id", userId)
-      .single();
-
-    if (profileError) {
-      // If no profile exists, return empty profile
-      if (profileError.code === "PGRST116") {
-        return {
-          firstName: null,
-          lastName: null,
-          bio: null,
-          targetLanguages: [],
-          profilePicture: null,
-          nativeLanguage: null,
-        };
-      }
-      const errorMessage =
-        profileError.message || `Supabase error: ${profileError.code || "Unknown"}`;
-      const enhancedError = new Error(errorMessage);
-      (enhancedError as any).code = profileError.code;
-      (enhancedError as any).details = profileError.details;
-      throw enhancedError;
+    const res = await fetch("/api/profile/me");
+    const body = await res.json();
+    if (!res.ok) {
+      throw new Error(body?.error || "Failed to load profile");
     }
-
-    // Fetch ALL target languages
-    const { data: targetLanguagesData, error: targetLanguagesError } = await supabase
-      .from("profile_target_languages")
-      .select("level, languages!profile_target_languages_language_id_fkey(name)")
-      .eq("user_id", userId);
-
-    if (targetLanguagesError) {
-      const errorMessage =
-        targetLanguagesError.message ||
-        `Supabase error: ${targetLanguagesError.code || "Unknown"}`;
-      const enhancedError = new Error(errorMessage);
-      (enhancedError as any).code = targetLanguagesError.code;
-      (enhancedError as any).details = targetLanguagesError.details;
-      throw enhancedError;
-    }
-
-    const targetLanguages: TargetLanguage[] = (targetLanguagesData ?? [])
-      .map((row: any) => {
-        const name = row?.languages?.name ?? null;
-        if (!name) return null;
-        return {
-          name,
-          level: levelToDisplay(row.level),
-        };
-      })
-      .filter(Boolean) as TargetLanguage[];
-
-    return {
-      firstName: profileData.first_name,
-      lastName: profileData.last_name,
-      bio: profileData.bio,
-      targetLanguages,
-      profilePicture: profileData.profile_picture_url,
-      nativeLanguage: profileData.native_language,
-    };
+    return body.profile as Profile;
   } catch (e) {
     if (e instanceof Error && (e.name === "AbortError" || e.message.includes("aborted"))) {
       throw new Error("Network request was cancelled. Please check your connection and try again.");
@@ -166,9 +83,10 @@ export default function ProfilePage() {
     setError(null);
 
     try {
-      const { error: signOutError } = await supabase.auth.signOut();
-      if (signOutError) {
-        setError(signOutError.message);
+      const res = await fetch("/api/auth/signout", { method: "POST" });
+      const body = await res.json();
+      if (!res.ok) {
+        setError(body?.error || "Sign out failed");
         setSignOutLoading(false);
         return;
       }
@@ -185,55 +103,30 @@ export default function ProfilePage() {
     setError(null);
 
     try {
-      console.log("Starting account deletion process...");
+      const res = await fetch("/api/profile/delete", { method: "POST" });
+      const body = await res.json();
 
-      const {
-        data: { user },
-        error: userError,
-      } = await supabase.auth.getUser();
-      if (userError || !user) {
-        setError("Could not get user information");
-        setDeleteLoading(false);
-        return;
-      }
-
-      const userId = user.id;
-
-      const { data: rpcData, error: deleteAuthError } = await supabase.rpc(
-        "delete_user_account",
-        { user_uuid: userId }
-      );
-
-      if (deleteAuthError) {
-        if (
-          deleteAuthError.message?.includes("function") ||
-          deleteAuthError.code === "42883" ||
-          deleteAuthError.message?.includes("does not exist")
-        ) {
+      if (!res.ok) {
+        const errMsg = String(body?.error || "Account deletion failed");
+        const errCode = String(body?.code || "");
+        if (errMsg.includes("function") || errCode === "42883" || errMsg.includes("does not exist")) {
           setError(
             "Delete account function not set up. Please run delete_user_account.sql in Supabase SQL Editor, or contact support."
           );
-        } else if (deleteAuthError.message?.includes("Not authenticated")) {
+        } else if (errMsg.includes("Not authenticated")) {
           setError("Authentication error. Please try signing out and back in.");
-        } else if (deleteAuthError.message?.includes("only delete your own")) {
+        } else if (errMsg.includes("only delete your own")) {
           setError("Security error: You can only delete your own account.");
         } else {
           setError(
-            `Account data deleted, but auth user deletion failed: ${
-              deleteAuthError.message || "Unknown error"
-            }. Please contact support.`
+            `Account data deleted, but auth user deletion failed: ${errMsg}. Please contact support.`
           );
         }
-        await supabase.auth.signOut();
         setDeleteLoading(false);
         router.push("/auth/signin");
         return;
       }
 
-      console.log("✅ Account and all related data deleted successfully!");
-      console.log("RPC response:", rpcData);
-
-      await supabase.auth.signOut();
       router.push("/");
     } catch (e) {
       const msg = e instanceof Error ? e.message : "An unexpected error occurred";


### PR DESCRIPTION
**Title**
Move profile data access to API routes (backend-only Supabase)

**Summary**
- Migrate profile, edit-profile, and user-profile data fetching to `/api/profile` routes to keep Supabase access server-side.
- Added routes to `/api/friends`
- Add profile-related API endpoints (me, userId, languages, delete, start-conversation).
- Add auth signout and friends helper routes (status, unfriend), and return `conversationId` on accept.
- Solved the security problems with profile page solely
