### PR TITLE
Refine Discover filtering

### DIFF
--- a/language-learning/app/api/discover/route.ts
+++ b/language-learning/app/api/discover/route.ts
@@ -23,6 +23,10 @@ function rankLevel(level: string | null | undefined): number {
   return LEVEL_RANK[(level ?? "").toLowerCase()] ?? 0;
 }
 
+function normalizeLanguage(value: string | null | undefined): string {
+  return (value ?? "").trim().toLowerCase();
+}
+
 function firstRelation<T>(value: T | T[] | null | undefined): T | null {
   if (!value) return null;
   return Array.isArray(value) ? (value[0] ?? null) : value;
@@ -55,8 +59,14 @@ export async function GET(req: NextRequest) {
   ]);
 
   const userNative = userProfile?.native_language ?? "";
+  const userNativeNormalized = normalizeLanguage(userNative);
   const userTargets = new Map(userTargetRows?.map(r => [r.language_id, { name: (r.lang as any).name, level: r.level }]) ?? []);
-  const userTargetNameSet = new Set(userTargetRows?.map(r => (r.lang as any).name));
+  const userTargetNameSet = new Set(
+    (userTargetRows ?? [])
+      .map((r) => normalizeLanguage((r.lang as any).name))
+      .filter(Boolean)
+  );
+  const userLanguageSet = new Set([userNativeNormalized, ...userTargetNameSet].filter(Boolean));
   const userTargetIdSet = new Set(userTargets.keys());
 
   const friends = createFriendService(supabase);
@@ -138,18 +148,33 @@ export async function GET(req: NextRequest) {
     existing.targets.push(nextTarget);
   }
 
-  const scored = [...grouped.values()].map((candidate) => {
+  const scored = [...grouped.values()]
+    .filter((candidate) => {
+      const candidateLanguages = new Set<string>();
+      const candidateNative = normalizeLanguage(candidate.native_language);
+      if (candidateNative) candidateLanguages.add(candidateNative);
+      for (const target of candidate.targets) {
+        const normalizedTarget = normalizeLanguage(target.name);
+        if (normalizedTarget) candidateLanguages.add(normalizedTarget);
+      }
+
+      for (const lang of candidateLanguages) {
+        if (userLanguageSet.has(lang)) return true;
+      }
+      return false;
+    })
+    .map((candidate) => {
       const candidateNativeLanguage = candidate.native_language ?? "";
       const sharedTargets = candidate.targets.filter((target) =>
         userTargetIdSet.has(target.language_id),
       );
       const hasSharedTarget = sharedTargets.length > 0;
 
-      const candidateLearnsUserNative = userNative
-        ? candidate.targets.some((target) => target.name === userNative)
+      const candidateLearnsUserNative = userNativeNormalized
+        ? candidate.targets.some((target) => normalizeLanguage(target.name) === userNativeNormalized)
         : false;
       const userLearnsCandidateNative = candidateNativeLanguage
-        ? userTargetNameSet.has(candidateNativeLanguage)
+        ? userTargetNameSet.has(normalizeLanguage(candidateNativeLanguage))
         : false;
       const isMutualExchange = candidateLearnsUserNative && userLearnsCandidateNative;
 


### PR DESCRIPTION
Closes #185 

Refine Discover filtering s.t other profiles w/ no overlap between target/native languages are excluded from Discover matching.

## Acceptance Criteria: 

- [ ] If a profile has **zero overlap** (native + learning both unrelated), it is excluded from:
  - [ ] `Recommended for You`
  - [ ] `All Potential Matches`
- [ ] A profile is included if **any one** of these is true:
  - [ ] Candidate native matches current user native
  - [ ] Candidate native matches any current user target language
  - [ ] Any candidate target language matches current user native
  - [ ] Any candidate target language matches any current user target language
