### PR TITLE
kun - added realtime typing indicator

### DIFF
--- a/language-learning/app/api/chats/room/[roomId]/events/route.ts
+++ b/language-learning/app/api/chats/room/[roomId]/events/route.ts
@@ -1,0 +1,68 @@
+
+import { sseBroker } from "@/lib/sse-broker";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+function formatSse(event: string, data: unknown) {
+  return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+export async function GET(
+  req: Request,
+  { params }: { params: Promise<{ roomId: string }> }
+) {
+  const { roomId } = await params;
+  const url = new URL(req.url);
+  const userId = url.searchParams.get("userId");
+
+  if (!userId) {
+    return new Response("missing userId", { status: 400 });
+  }
+
+  const clientId = crypto.randomUUID();
+
+  let heartbeat: NodeJS.Timeout | null = null;
+
+  const stream = new ReadableStream({
+    start(controller) {
+      const encoder = new TextEncoder();
+
+      const send = (event: string, data: unknown) => {
+        controller.enqueue(encoder.encode(formatSse(event, data)));
+      };
+
+      const close = () => {
+        try {
+          controller.close();
+        } catch {}
+      };
+
+      sseBroker.addClient(roomId, {
+        id: clientId,
+        userId,
+        send,
+        close,
+      });
+
+      send("connected", { ok: true, clientId });
+
+      heartbeat = setInterval(() => {
+        controller.enqueue(encoder.encode(`: keep-alive\n\n`));
+      }, 15000);
+    },
+
+    cancel() {
+      if (heartbeat) clearInterval(heartbeat);
+      sseBroker.removeClient(roomId, clientId);
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream; charset=utf-8",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+    },
+  });
+}

--- a/language-learning/app/api/chats/room/[roomId]/typing/route.ts
+++ b/language-learning/app/api/chats/room/[roomId]/typing/route.ts
@@ -1,0 +1,32 @@
+import { sseBroker } from "@/lib/sse-broker";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ roomId: string }> }
+) {
+  const { roomId } = await params;
+
+  const body = await req.json().catch(() => null);
+  const userId = body?.userId;
+  const isTyping = body?.isTyping;
+
+  if (typeof userId !== "string" || typeof isTyping !== "boolean") {
+    return Response.json({ error: "invalid payload" }, { status: 400 });
+  }
+
+  sseBroker.broadcast(
+    roomId,
+    "typing",
+    {
+      userId,
+      isTyping,
+      ts: Date.now(),
+    },
+    userId
+  );
+
+  return Response.json({ ok: true });
+}

--- a/language-learning/app/chats/ChatsClient.tsx
+++ b/language-learning/app/chats/ChatsClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import Chat, { Conversation } from "@/components/chat/Chat";
 
@@ -16,6 +16,12 @@ type ProfileForChats = {
   nativeLanguage?: string | null;
 };
 
+type TypingEventPayload = {
+  userId?: string;
+  isTyping?: boolean;
+  ts?: number;
+};
+
 export default function ChatsClient({ cFromUrl }: { cFromUrl: string | null }) {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -26,6 +32,9 @@ export default function ChatsClient({ cFromUrl }: { cFromUrl: string | null }) {
 
   const [conversations, setConversations] = useState<Conversation[]>([]);
   const [selectedConversationId, setSelectedConversationId] = useState<string | null>(null);
+  const [typingByConversationId, setTypingByConversationId] = useState<Record<string, boolean>>({});
+
+  const typingTimeoutsRef = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
 
   const c = searchParams.get("c") ?? cFromUrl;
 
@@ -153,6 +162,24 @@ export default function ChatsClient({ cFromUrl }: { cFromUrl: string | null }) {
         };
       })
     );
+
+    setTypingByConversationId((prev) =>
+      prev[conversationId] ? { ...prev, [conversationId]: false } : prev
+    );
+  }
+
+  async function handleTypingChange(conversationId: string, isTyping: boolean) {
+    if (!myUserId) return;
+
+    try {
+      await fetch(`/api/chats/room/${encodeURIComponent(conversationId)}/typing`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ userId: myUserId, isTyping }),
+      });
+    } catch (error) {
+      console.error("typing update failed:", error);
+    }
   }
 
   // Load messages for initial selection once it is known
@@ -160,6 +187,63 @@ export default function ChatsClient({ cFromUrl }: { cFromUrl: string | null }) {
     if (!selectedConversationId || !myUserId) return;
 
     loadMessagesForConversation(selectedConversationId, myUserId).catch(console.error);
+  }, [selectedConversationId, myUserId]);
+
+  useEffect(() => {
+    if (!selectedConversationId || !myUserId) return;
+
+    const conversationId = selectedConversationId;
+    const eventSource = new EventSource(
+      `/api/chats/room/${encodeURIComponent(conversationId)}/events?userId=${encodeURIComponent(myUserId)}`
+    );
+
+    const clearTypingTimeout = () => {
+      const timeout = typingTimeoutsRef.current[conversationId];
+      if (timeout) {
+        clearTimeout(timeout);
+        delete typingTimeoutsRef.current[conversationId];
+      }
+    };
+
+    const setPartnerTyping = (isTyping: boolean) => {
+      setTypingByConversationId((prev) =>
+        prev[conversationId] === isTyping ? prev : { ...prev, [conversationId]: isTyping }
+      );
+    };
+
+    const handleTyping = (event: MessageEvent<string>) => {
+      try {
+        const payload = JSON.parse(event.data) as TypingEventPayload;
+
+        if (payload.userId === myUserId || typeof payload.isTyping !== "boolean") {
+          return;
+        }
+
+        if (!payload.isTyping) {
+          clearTypingTimeout();
+          setPartnerTyping(false);
+          return;
+        }
+
+        setPartnerTyping(true);
+        clearTypingTimeout();
+        typingTimeoutsRef.current[conversationId] = setTimeout(() => {
+          setPartnerTyping(false);
+          delete typingTimeoutsRef.current[conversationId];
+        }, 4000);
+      } catch (error) {
+        console.error("invalid typing event:", error);
+      }
+    };
+
+    eventSource.addEventListener("typing", handleTyping as EventListener);
+
+    return () => {
+      clearTypingTimeout();
+      setPartnerTyping(false);
+      eventSource.removeEventListener("typing", handleTyping as EventListener);
+      eventSource.close();
+    };
   }, [selectedConversationId, myUserId]);
 
   if (loading) {
@@ -198,6 +282,10 @@ export default function ChatsClient({ cFromUrl }: { cFromUrl: string | null }) {
           if (myUserId) loadMessagesForConversation(id, myUserId).catch(console.error);
         }}
         onSendMessage={handleSendMessage}
+        onTypingChange={handleTypingChange}
+        isPartnerTyping={
+          selectedConversationId ? Boolean(typingByConversationId[selectedConversationId]) : false
+        }
       />
     </div>
   );

--- a/language-learning/components/chat/Chat.tsx
+++ b/language-learning/components/chat/Chat.tsx
@@ -46,7 +46,9 @@ type ChatProps = {
   selectedConversationId: string | null;
   onSelectConversationId?: (conversationId: string) => void;
   onSendMessage?: (conversationId: string, text: string) => Promise<void>;
+  onTypingChange?: (conversationId: string, isTyping: boolean) => Promise<void> | void;
   myNativeLanguage?: string | null;
+  isPartnerTyping?: boolean;
 };
 
 export default function Chat({
@@ -54,7 +56,9 @@ export default function Chat({
   selectedConversationId,
   onSelectConversationId,
   onSendMessage,
+  onTypingChange,
   myNativeLanguage,
+  isPartnerTyping = false,
 }: ChatProps) {
   function handleSelectConversation(id: string) {
     onSelectConversationId?.(id);
@@ -99,8 +103,13 @@ export default function Chat({
               messages={selected.messages}
               conversationId={selected.conversationId}
               myNativeLanguage={myNativeLanguage ?? null}
+              isPartnerTyping={isPartnerTyping}
               onSendMessage={async (conversationId, text) => {
-                await onSendMessage?.(conversationId, text); }}
+                await onSendMessage?.(conversationId, text);
+              }}
+              onTypingChange={(conversationId, typing) => {
+                return onTypingChange?.(conversationId, typing);
+              }}
             />
           ) : (
             <div className="flex h-full items-center justify-center rounded-2xl border bg-white px-6 text-gray-muted shadow-sm">

--- a/language-learning/components/chat/ChatHeader.tsx
+++ b/language-learning/components/chat/ChatHeader.tsx
@@ -10,6 +10,7 @@ type ChatHeaderProps = {
   partnerLastName: string;
   partnerAvatarUrl: string | null;
   targetLanguages?: string[];
+  typingLabel?: string | null;
 };
 
 export default function ChatHeader({
@@ -18,18 +19,23 @@ export default function ChatHeader({
   partnerLastName,
   partnerAvatarUrl,
   targetLanguages,
+  typingLabel,
 }: ChatHeaderProps) {
   return (
     <div className="border-b border-gray-border-soft px-5 py-4">
       <div className="flex items-center gap-3">
         <Avatar src={partnerAvatarUrl} alt={`${partnerFirstName} ${partnerLastName}`} />
 
-        <div>
+        <div className="min-w-0">
           <Link href={`/profile/${partnerId}`} className="text-base font-semibold text-gray-text hover:underline">
             {partnerFirstName} {partnerLastName}
           </Link>
 
-          {targetLanguages && targetLanguages.length > 0 ? (
+          {typingLabel ? (
+            <div className="text-sm font-medium text-blue-dark" aria-live="polite">
+              {typingLabel}
+            </div>
+          ) : targetLanguages && targetLanguages.length > 0 ? (
             <div className="text-sm text-gray-muted-2">
               Learning:{" "}
               <span className="font-medium text-gray-muted">

--- a/language-learning/components/chat/ChatRightPanel.tsx
+++ b/language-learning/components/chat/ChatRightPanel.tsx
@@ -21,7 +21,9 @@ type ChatLayoutProps = {
   messages: Message[];
   conversationId: string;
   onSendMessage: (conversationId: string, text: string) => Promise<void>;
+  onTypingChange?: (conversationId: string, isTyping: boolean) => Promise<void> | void;
   myNativeLanguage: string | null;
+  isPartnerTyping?: boolean;
 };
 
 export default function ChatRightPanel({
@@ -33,7 +35,9 @@ export default function ChatRightPanel({
   messages,
   conversationId,
   onSendMessage,
+  onTypingChange,
   myNativeLanguage,
+  isPartnerTyping = false,
 }: ChatLayoutProps) {
   return (
     <div className="h-[calc(100dvh-72px)] flex flex-col overflow-hidden">
@@ -44,6 +48,7 @@ export default function ChatRightPanel({
           partnerLastName={partnerLastName}
           partnerAvatarUrl={partnerAvatarUrl}
           targetLanguages={targetLanguages}
+          typingLabel={isPartnerTyping ? `${partnerFirstName} is typing...` : null}
         />
       </div>
 
@@ -58,7 +63,10 @@ export default function ChatRightPanel({
       </div>
 
       <div className="shrink-0 border-t border-gray-border-soft px-4 py-3">
-        <MessageComposer onSend={(text) => onSendMessage(conversationId, text)} />
+        <MessageComposer
+          onSend={(text) => onSendMessage(conversationId, text)}
+          onTypingChange={(isTyping) => onTypingChange?.(conversationId, isTyping)}
+        />
       </div>
     </div>
   );

--- a/language-learning/components/chat/MessageComposer.tsx
+++ b/language-learning/components/chat/MessageComposer.tsx
@@ -3,7 +3,7 @@
 
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   RegExpMatcher,
   englishDataset,
@@ -29,21 +29,56 @@ export function censorProfanity(input: string): string {
 
 type MessageComposerProps = {
   onSend: (text: string) => Promise<void> | void;
+  onTypingChange?: (isTyping: boolean) => Promise<void> | void;
 };
 
-export default function MessageComposer({ onSend }: MessageComposerProps) {
+export default function MessageComposer({ onSend, onTypingChange }: MessageComposerProps) {
   const [text, setText] = useState("");
   const [suppressDisabledStyle, setSuppressDisabledStyle] = useState(false);
 
+  const typingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isTypingRef = useRef(false);
+
   const canSend = text.trim().length > 0;
+
+  function clearTypingTimeout() {
+    if (!typingTimeoutRef.current) return;
+
+    clearTimeout(typingTimeoutRef.current);
+    typingTimeoutRef.current = null;
+  }
+
+  function emitTyping(isTyping: boolean) {
+    if (isTypingRef.current === isTyping) return;
+
+    isTypingRef.current = isTyping;
+    void onTypingChange?.(isTyping);
+  }
+
+  function scheduleTypingStop() {
+    clearTypingTimeout();
+    typingTimeoutRef.current = setTimeout(() => {
+      emitTyping(false);
+      typingTimeoutRef.current = null;
+    }, 2200);
+  }
+
+  useEffect(() => {
+    return () => {
+      clearTypingTimeout();
+      emitTyping(false);
+    };
+  }, []);
 
   async function handleSend() {
     if (!canSend) return;
     const trimmed = text.trim();
     const sanitized = censorProfanity(trimmed);
+    clearTypingTimeout();
+    emitTyping(false);
     setText("");
     await onSend(sanitized);
-    setSuppressDisabledStyle(true)
+    setSuppressDisabledStyle(true);
   }
 
   async function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
@@ -55,6 +90,19 @@ export default function MessageComposer({ onSend }: MessageComposerProps) {
     }
   }
 
+  function handleChange(nextValue: string) {
+    setText(nextValue);
+
+    if (nextValue.trim().length === 0) {
+      clearTypingTimeout();
+      emitTyping(false);
+      return;
+    }
+
+    emitTyping(true);
+    scheduleTypingStop();
+  }
+
   return (
     <div className="flex items-stretch gap-3">
         {/* Text box */}
@@ -64,7 +112,11 @@ export default function MessageComposer({ onSend }: MessageComposerProps) {
             rows={1}
             placeholder="Type a message…"
             value={text}
-            onChange={(e) => setText(e.target.value)}
+            onBlur={() => {
+              clearTypingTimeout();
+              emitTyping(false);
+            }}
+            onChange={(e) => handleChange(e.target.value)}
             onKeyDown={handleKeyDown}
             className="
             h-12 w-full resize-none rounded-2xl px-4 py-3 text-sm leading-5

--- a/language-learning/lib/sse-broker.ts
+++ b/language-learning/lib/sse-broker.ts
@@ -1,0 +1,57 @@
+type Client = {
+  id: string;
+  userId: string;
+  send: (event: string, data: unknown) => void;
+  close: () => void;
+};
+
+class SseBroker {
+  private rooms = new Map<string, Map<string, Client>>();
+
+  addClient(roomId: string, client: Client) {
+    if (!this.rooms.has(roomId)) {
+      this.rooms.set(roomId, new Map());
+    }
+    this.rooms.get(roomId)!.set(client.id, client);
+    console.log(this.rooms)
+  }
+
+  removeClient(roomId: string, clientId: string) {
+    const room = this.rooms.get(roomId);
+    if (!room) return;
+
+    room.delete(clientId);
+    if (room.size === 0) {
+      this.rooms.delete(roomId);
+    }
+    console.log(this.rooms)
+  }
+
+  broadcast(
+    roomId: string,
+    event: string,
+    payload: unknown,
+    excludeUserId?: string
+  ) {
+    const room = this.rooms.get(roomId);
+    if (!room) return;
+
+    for (const [, client] of room) {
+      if (excludeUserId && client.userId === excludeUserId) continue;
+
+      try {
+        client.send(event, payload);
+      } catch {
+        this.removeClient(roomId, client.id);
+      }
+    }
+    console.log(this.rooms)
+  }
+}
+
+declare global {
+  var __sseBroker__: SseBroker | undefined;
+}
+
+export const sseBroker = globalThis.__sseBroker__ ?? new SseBroker();
+globalThis.__sseBroker__ = sseBroker;


### PR DESCRIPTION
closes #194 

# Summary

Add frontend SSE typing indicator support for chat conversations.

This PR wires the existing room-level SSE and typing APIs into the chat UI so users can see when the other participant is currently typing. It also improves the reliability of the in-memory SSE broker in Next.js by ensuring the broker is shared through `globalThis`.

# Changes

- Subscribe to room SSE events from the chat client using `EventSource`
- Listen for `typing` events and update per-conversation typing state in the frontend
- Send `POST /api/chats/room/[roomId]/typing` from the message composer when the user starts/stops typing
- Add debounce and timeout handling so typing status clears automatically
- Display `X is typing...` in the chat header
- Persist the SSE broker on `globalThis` so route handlers share the same broker instance

# Details

- `ChatsClient` now:
  - opens an `EventSource` connection for the selected conversation
  - listens for `typing` SSE events
  - tracks typing status by conversation ID
  - posts typing state updates to the room typing endpoint

- `MessageComposer` now:
  - emits `isTyping: true` when the user starts typing
  - emits `isTyping: false` after inactivity, on blur, on clear, and on send
  - uses a local debounce to avoid sending requests on every keystroke

- `ChatRightPanel` / `ChatHeader` now:
  - receive typing state as props
  - show `PartnerName is typing...` in the header area


